### PR TITLE
Fix Firebase SDK dependency conflicts on iOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "sdkVersions": {
     "ios": {
-      "firebase": "~> 7.7.0"
+      "firebase": "~> 7.7"
     }
   },
   "repository": {


### PR DESCRIPTION
When using this package together with the latest version of `@react-native-firebase/app`, a conflict between pod versions appears due to (I guess) a typo in dependencies for this package.